### PR TITLE
Adding top and left is not necessary when materialize.css is attached…

### DIFF
--- a/src/components/dropdown-list/index.ts
+++ b/src/components/dropdown-list/index.ts
@@ -56,14 +56,10 @@ export default class DropdownList {
     computeStyle(element: HTMLElement) {
         var offset = Utils.getOffset(element);
         var width = element.offsetWidth || 100;
-        var top = offset.top  || 0;
-        var left = offset.left  || 0;
 
         return {
             width: width + 'px',
             position: 'absolute',
-            top: top + 'px',
-            left: left + 'px',
             opacity: 1,
             display: 'block'
         };


### PR DESCRIPTION
… and it can even cause issues.

I have tested it with different positions in DOM and it is working perfectly fine without it.
It's small change but for me it was causing issues when md-dropdown is used by form:md-select.