### PR TITLE
Update Form/Select index.ts

### DIFF
--- a/src/components/form/select/index.ts
+++ b/src/components/form/select/index.ts
@@ -24,6 +24,7 @@ var Vue: any = Vue || require('vue');
         'select::select': function(value) {
             if (Array.isArray(this.value)) {
                 this.value.push(value);
+                this.uniqueMultipleValues();
             }
             else {
                 this.value = value;
@@ -36,6 +37,7 @@ var Vue: any = Vue || require('vue');
         'select::unselect': function(value) {
             if (Array.isArray(this.value)) {
                 this.value.$remove(value);
+                this.uniqueMultipleValues();
             }
             else {
                 this.value = value;
@@ -151,8 +153,19 @@ export default class SelectField {
         });
     }
 
+    uniqueMultipleValues() {
+		var uniqueValues = [];
+		this.value.forEach(function(item) {
+			if (uniqueValues.indexOf(item) < 0) {
+				uniqueValues.push(item);
+			}
+		});
+		this.value = uniqueValues;
+    }
+
     open(e) {
         if (!this.active) {
+            this.refreshDropdownOptions();
             this.active = true;
             this.$broadcast('dropdown-list::open', e);
         }
@@ -160,6 +173,7 @@ export default class SelectField {
 
     close() {
         if (this.active) {
+            this.refreshDropdownOptions();
             this.active = false;
             this.$broadcast('dropdown-list::close');
         }


### PR DESCRIPTION
If form data loading from ajax, md-select (Options example: 1, 2, 3) sync value recognize values [1, 3] only in input, but not in select dropdown list (checkboxes are not checked). If try to select options, they added to values array, so i get [1, 3, 3, 2] with dublicates, but not displaying in select input. Added methods to get unique select values and sync selected data on list open and close.