### PR TITLE
Change require("Vue") to require ("vue")

### DIFF
--- a/dist/vue-material-components.js
+++ b/dist/vue-material-components.js
@@ -1,12 +1,12 @@
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory(require("Vue"));
+		module.exports = factory(require("vue"));
 	else if(typeof define === 'function' && define.amd)
-		define(["Vue"], factory);
+		define(["vue"], factory);
 	else if(typeof exports === 'object')
-		exports["VueMaterialComponents"] = factory(require("Vue"));
+		exports["VueMaterialComponents"] = factory(require("vue"));
 	else
-		root["VueMaterialComponents"] = factory(root["Vue"]);
+		root["VueMaterialComponents"] = factory(root["vue"]);
 })(this, function(__WEBPACK_EXTERNAL_MODULE_2__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache


### PR DESCRIPTION
Due to nameing conventions, requiring Vue will not resolve. The package is lowercase 'vue'